### PR TITLE
updated path mismatches

### DIFF
--- a/workbench/transformations/skills/create-ontology/SKILL.md
+++ b/workbench/transformations/skills/create-ontology/SKILL.md
@@ -24,7 +24,7 @@ When a concept has a natural key, rows from different source tables that share t
 
 ### 1. Build entity list
 
-Read `.schema/taxonomy.json`. For each top-level key that is not prefixed with `_` (i.e. not `_version`, `_excluded`):
+Read `.schema/<cdm-name>/taxonomy.json`. For each top-level key that is not prefixed with `_` (i.e. not `_version`, `_excluded`):
 - Create one ontology entity per canonical concept
 - Name = concept key (PascalCase)
 - Mark as `inferred: false` (grounded in confirmed source mappings)
@@ -107,7 +107,7 @@ Present gaps to the user before writing output.
 
 ### 6. Write ontology
 
-Write `.schema/ontology.ison` in Graph ISON format (https://graph.ison.dev/) — tabular DSV sections, NOT JSON:
+Write `.schema/<cdm-name>/ontology.ison` in Graph ISON format (https://graph.ison.dev/) — tabular DSV sections, NOT JSON:
 
 ```ison
 nodes.Entity
@@ -151,7 +151,7 @@ Contract  track subscription billing     no source table found
 After writing both files, explicitly ask the user to open and review `.schema/<cdm-name>/ontology.md` before continuing:
 
 ```
-Please review `.schema/ontology.md` — it summarises every entity, its attributes, and the relationships between them.
+Please review `.schema/<cdm-name>/ontology.md` — it summarises every entity, its attributes, and the relationships between them.
 
 Let me know if anything looks wrong or needs changing before we move on.
 ```

--- a/workbench/transformations/skills/create-transformation/SKILL.md
+++ b/workbench/transformations/skills/create-transformation/SKILL.md
@@ -46,9 +46,9 @@ uv add "dlt[hub]"
 ### 2. Read inputs
 
 Read in parallel:
-- `.schema/annotated-sources.dbml` — source columns and their concept mappings
-- `.schema/taxonomy.json` — table mappings and natural keys
-- `.schema/CDM.dbml` — CDM entity definitions and column specs
+- `.schema/<cdm-name>/<pipeline_name>.dbml` — annotated source columns and their concept mappings (one file per pipeline)
+- `.schema/<cdm-name>/taxonomy.json` — table mappings and natural keys
+- `.schema/<cdm-name>/CDM.dbml` — CDM entity definitions and column specs
 
 ### 3. Get actual source schema
 
@@ -64,7 +64,7 @@ relation = dataset.<table_name>
 schema = relation.schema()  # authoritative column list
 ```
 
-Cross-check the annotated columns in `annotated-sources.dbml` against the schema from `relation.schema()`. Note any discrepancies.
+Cross-check the annotated columns in `.schema/<cdm-name>/<pipeline_name>.dbml` against the schema from `relation.schema()`. Note any discrepancies.
 
 ### 4. Plan transformation order
 
@@ -239,14 +239,14 @@ if __name__ == "__main__":
     source_pipeline = dlt.attach(pipeline_name="<source_pipeline_name>")
     source_dataset = source_pipeline.dataset()
 
-    load_info = source_pipeline.run(<business_domain>_to_cdm(source_dataset))
+    load_info = source_pipeline.run(<dataset_name>_to_cdm(source_dataset))
     print(load_info)
 ```
 
 **Naming convention:** `pipeline_name` and `dataset_name` should reflect the **business domain and central fact**, not the source systems. Derive the name from:
-1. The central fact table in `.schema/CDM.dbml` (e.g. `fact_interaction` → `interactions`)
-2. The primary dimension in `.schema/ontology.ison` (e.g. `Person`)
-3. The use cases in `.schema/taxonomy.json`
+1. The central fact table in `.schema/<cdm-name>/CDM.dbml` (e.g. `fact_interaction` → `interactions`)
+2. The primary dimension in `.schema/<cdm-name>/ontology.ison` (e.g. `Person`)
+3. The use cases in `.schema/<cdm-name>/taxonomy.json`
 
 Name the dataset after the grain of the star schema — what the data mart *is about*: `person_interactions`, `order_fulfillment`, `event_attendance`. Never use source system names (`hubspot_stripe_cdm`) or generic names (`combined_cdm`, `my_pipeline`). A good name tells an analyst what business process lives in the dataset without reading the code.
 

--- a/workbench/transformations/skills/generate-cdm/SKILL.md
+++ b/workbench/transformations/skills/generate-cdm/SKILL.md
@@ -18,7 +18,7 @@ Reference: DBML format — https://dbml.dbdiagram.io/
 
 ### 1. Classify entities as fact or dimension
 
-Read `.schema/ontology.ison`. For each entity, apply Kimball classification:
+Read `.schema/<cdm-name>/ontology.ison`. For each entity, apply Kimball classification:
 
 | Signals | Classification |
 |---|---|
@@ -85,7 +85,7 @@ If a new collapse is warranted, confirm with the user before merging the tables.
 
 ### 6. Write CDM
 
-Write `.schema/CDM.dbml` using DBML syntax. Encode metadata in `Table` notes:
+Write `.schema/<cdm-name>/CDM.dbml` using DBML syntax. Encode metadata in `Table` notes:
 
 ```dbml
 Table dim_person [note: 'table_type:dimension; surrogate_key:person_sk; scd_type:1; conformed:true'] {


### PR DESCRIPTION
# Changes by File

## `workbench/transformations/skills/create-ontology/SKILL.md`

* **Step 1**

  * **Before:** Read `.schema/taxonomy.json`
  * **After:** Read `.schema/<cdm-name>/taxonomy.json`

* **Step 6**

  * **Before:** Write `.schema/ontology.ison`
  * **After:** Write `.schema/<cdm-name>/ontology.ison`

* **Review prompt**

  * **Before:** Please review `.schema/ontology.md`
  * **After:** Please review `.schema/<cdm-name>/ontology.md`

---

## `workbench/transformations/skills/generate-cdm/SKILL.md`

* **Step 1**

  * **Before:** Read `.schema/ontology.ison`
  * **After:** Read `.schema/<cdm-name>/ontology.ison`

* **Step 6**

  * **Before:** Write `.schema/CDM.dbml`
  * **After:** Write `.schema/<cdm-name>/CDM.dbml`

---

## `workbench/transformations/skills/create-transformation/SKILL.md`

* **Step 2 – Input list**

  * **Before:**

    * `.schema/annotated-sources.dbml`
    * `.schema/taxonomy.json`
    * `.schema/CDM.dbml`
  * **After:**

    * `.schema/<cdm-name>/<pipeline_name>.dbml` (per pipeline)
    * `.schema/<cdm-name>/taxonomy.json`
    * `.schema/<cdm-name>/CDM.dbml`

* **Step 3 – Cross-check**

  * **Before:** `annotated-sources.dbml`
  * **After:** `.schema/<cdm-name>/<pipeline_name>.dbml`

* **Naming convention section**

  * **Before:**

    * `.schema/CDM.dbml`
    * `.schema/ontology.ison`
    * `.schema/taxonomy.json`
  * **After:**

    * `.schema/<cdm-name>/CDM.dbml`
    * `.schema/<cdm-name>/ontology.ison`
    * `.schema/<cdm-name>/taxonomy.json`

* **`__main__` entrypoint**

  * **Before:** `<business_domain>_to_cdm(source_dataset)`
  * **After:** `<dataset_name>_to_cdm(source_dataset)` (now matches the `@dlt.source` definition `<dataset_name>_to_cdm` declared above it)
