### PR TITLE
[Incremental] add info about lag

### DIFF
--- a/workbench/rest-api-pipeline/skills/adjust-endpoint/SKILL.md
+++ b/workbench/rest-api-pipeline/skills/adjust-endpoint/SKILL.md
@@ -40,6 +40,7 @@ Load only new or updated records each run instead of re-fetching everything. In 
                 "type": "incremental",
                 "cursor_path": "updated_at", # field in each record to track
                 "initial_value": "2024-01-01T00:00:00Z",
+                "lag": 604800,               # re-load a trailing window (see below)
             },
         },
     },
@@ -53,6 +54,7 @@ Key decisions:
 - **`cursor_path`**: the field in each record holding the cursor value (e.g. `updated_at`).
 - **`initial_value`**: where the first run starts — also how you **expand or shrink the backfill date range**.
 - **`write_disposition: "merge"` + `primary_key`**: required so updated records upsert instead of duplicating.
+- **`lag`** (Optional): re-load a trailing window each run so late-arriving or back-dated updates are caught. **The unit is inferred from the shape of the cursor value, not from your config** — dlt sniffs it with `detect_datetime_format`: a date (`"2026-08-27"`) gets **days**, a datetime (`"2026-08-27T00:00:00Z"`) gets **seconds**. So "re-load the last 7 days" is `lag=7` on a date cursor but `lag=604800` on a datetime cursor. Requires `merge` + `primary_key`, or the re-fetched rows duplicate. Ref: https://dlthub.com/docs/general-usage/incremental/lag
 
 dlt stores the last cursor value in pipeline state and resumes next run — check it with `uv run dlthub local pipeline info <name> -v` (look for `last_value`).
 

--- a/workbench/sql-database-pipeline/skills/adjust-table/SKILL.md
+++ b/workbench/sql-database-pipeline/skills/adjust-table/SKILL.md
@@ -60,6 +60,7 @@ Key decisions:
 - **`write_disposition="merge"`**: required with incremental — replaces rows with matching primary key
 - **`primary_key`**: set this to the table's primary key so upserts work correctly
 - **`initial_value`**: where to start on the very first run — older values are excluded
+- **`lag`** (Optional): re-load a trailing window each run so late-arriving or back-dated updates are caught. **The unit is inferred from the shape of the cursor value, not from your config** — dlt sniffs it with `detect_datetime_format`: a date (`"2026-08-27"`) gets **days**, a datetime (`"2026-08-27T00:00:00Z"`) gets **seconds**. So "re-load the last 7 days" is `lag=7` on a date cursor but `lag=604800` on a datetime cursor. Needs `merge` + `primary_key`, or the re-fetched rows duplicate. Ref: https://dlthub.com/docs/general-usage/incremental/lag
 
 Check stored cursor state between runs:
 ```

--- a/workbench/transformations/skills/incremental-transformation/SKILL.md
+++ b/workbench/transformations/skills/incremental-transformation/SKILL.md
@@ -116,6 +116,7 @@ def orders_window(
 
 - **`range_start="open"` (default)**: excludes the last-seen cursor value on the next run, preventing double-processing the boundary row. Switch to `"closed"` only if the source may update the record exactly at the cursor boundary.
 - **`merge` requires `primary_key`**: without it, rows are not deduped — merge silently behaves like append.
+- **`lag`** (Optional): `lag` re-loads a trailing window so late-arriving rows are caught, but dlt infers the unit from the shape of the cursor value (`detect_datetime_format`) — a date (`"2026-08-27"`) gets **days**, a datetime (`"2026-08-27T00:00:00Z"`) gets **seconds**. "Last 7 days" is `lag=7` on a date cursor, `lag=604800` on a datetime one. Ref: https://dlthub.com/docs/general-usage/incremental/lag
 - **Load-based auto-join**: the dotted path `_dlt_loads.inserted_at` triggers an automatic join to the `_dlt_loads` table. Do not write the JOIN yourself.
 - **`columns=` hints still apply**: any column that may be NULL on the first incremental run needs an explicit `columns=` hint, same as in `create-transformation`.
 - **Same vs. different destination**: when source and target use the same physical destination (same DB file or host), dlthub pushes SQL directly without materializing data. Across different destinations, dlthub streams Arrow chunks automatically.


### PR DESCRIPTION
added info about how lag works:
 ▎ - Datetime cursors: lag is the number of seconds added or subtracted from the last_value loaded.
 ▎ - Date cursors: lag represents days.